### PR TITLE
Only try to record for files

### DIFF
--- a/plugin/gtm.vim
+++ b/plugin/gtm.vim
@@ -52,11 +52,14 @@ let s:gtm_plugin_status = ''
 function! s:record()
   let fpath = expand('%:p')
   " record if file path has changed or last update is greater than update_interval
-  if s:last_file != fpath || localtime() - s:last_update > s:update_interval
+  if filereadable(fpath) && (s:last_file != fpath || localtime() - s:last_update > s:update_interval)
     let s:cmd = (g:gtm_plugin_status_enabled == 1 ? 'gtm record --status' : 'gtm record')
     let output=system(s:cmd . ' ' . shellescape(fpath))
     if v:shell_error
       echoerr s:no_gtm_err
+      echom "Trying to record file: ".. fpath
+      echom "With command: ".. s:cmd .. ' ' .. shellescape(fpath)
+      echom output
     else
       let s:gtm_plugin_status = (g:gtm_plugin_status_enabled ? substitute(output, '\n\+$', '', '') : '')
     endif


### PR DESCRIPTION
Plugins like dirvish and netrw let you "edit" directories to see what's
in them. Using them triggers a panic in gtm, so don't do that.

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x20 pc=0x64d57e]

Also output the result of calling gtm so users can see whether it's
actually a path failure. Otherwise, gtm-vim's message may be confusing
(it led me astray).